### PR TITLE
Avoid expensive division in HashMap

### DIFF
--- a/slimcc.h
+++ b/slimcc.h
@@ -65,6 +65,7 @@ typedef struct {
   HashEntry *buckets;
   int capacity;
   int used;
+  int mask;
 } HashMap;
 
 void *hashmap_get(HashMap *map, char *key);


### PR DESCRIPTION
Previously, HashMap relied on division operations, which are expensive. This update replaces divisions with logical AND operations using an additional mask, improving performance.