### PR TITLE
Avoid unnecessary strlen + memcmp call

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,11 +18,11 @@ $(OBJS): slimcc.h
 
 test/%.exe: slimcc test/%.c
 	./slimcc -Iinclude -Itest -c -o test/$*.o test/$*.c
-	$(CC) -std=c11 -pthread -Wno-psabi -o $@ test/$*.o -xc test/common
+	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ test/$*.o -xc test/common
 
 test/c23/%.exe: slimcc test/c23/%.c
 	./slimcc -std=c23 -Iinclude -Itest -c -o test/c23/$*.o test/c23/$*.c
-	$(CC) -std=c11 -pthread -Wno-psabi -o $@ test/c23/$*.o -xc test/common
+	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ test/c23/$*.o -xc test/common
 
 test: $(TESTS) $(TESTS_C23)
 	for i in $^; do echo $$i; ./$$i || exit 1; echo; done
@@ -42,12 +42,12 @@ stage2/%.o: slimcc %.c
 stage2/test/%.exe: stage2/slimcc test/%.c
 	mkdir -p stage2/test
 	./stage2/slimcc -Iinclude -Itest -c -o stage2/test/$*.o test/$*.c
-	$(CC) -std=c11 -pthread -Wno-psabi -o $@ stage2/test/$*.o -xc test/common
+	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ stage2/test/$*.o -xc test/common
 
 stage2/test/c23/%.exe: stage2/slimcc test/c23/%.c
 	mkdir -p stage2/test/c23
 	./stage2/slimcc -std=c23 -Iinclude -Itest -c -o stage2/test/c23/$*.o test/c23/$*.c
-	$(CC) -std=c11 -pthread -Wno-psabi -o $@ stage2/test/c23/$*.o -xc test/common
+	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ stage2/test/c23/$*.o -xc test/common
 
 test-stage2: $(TESTS:test/%=stage2/test/%) $(TESTS_C23:test/c23/%=stage2/test/c23/%)
 	for i in $^; do echo $$i; ./$$i || exit 1; echo; done

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,5 +1,7 @@
 CFLAGS=-std=c99 -g -fno-common -Wall -pedantic -Wno-switch
 
+TEST_FLAGS=-Iinclude -Itest -fenable-universal-char
+
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 
@@ -17,11 +19,11 @@ slimcc: $(OBJS)
 $(OBJS): slimcc.h
 
 test/%.exe: slimcc test/%.c
-	./slimcc -Iinclude -Itest -c -o test/$*.o test/$*.c
+	./slimcc $(TEST_FLAGS) -c -o test/$*.o test/$*.c
 	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ test/$*.o -xc test/common
 
 test/c23/%.exe: slimcc test/c23/%.c
-	./slimcc -std=c23 -Iinclude -Itest -c -o test/c23/$*.o test/c23/$*.c
+	./slimcc -std=c23 $(TEST_FLAGS) -c -o test/c23/$*.o test/c23/$*.c
 	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ test/c23/$*.o -xc test/common
 
 test: $(TESTS) $(TESTS_C23)
@@ -41,12 +43,12 @@ stage2/%.o: slimcc %.c
 
 stage2/test/%.exe: stage2/slimcc test/%.c
 	mkdir -p stage2/test
-	./stage2/slimcc -Iinclude -Itest -c -o stage2/test/$*.o test/$*.c
+	./stage2/slimcc $(TEST_FLAGS) -c -o stage2/test/$*.o test/$*.c
 	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ stage2/test/$*.o -xc test/common
 
 stage2/test/c23/%.exe: stage2/slimcc test/c23/%.c
 	mkdir -p stage2/test/c23
-	./stage2/slimcc -std=c23 -Iinclude -Itest -c -o stage2/test/c23/$*.o test/c23/$*.c
+	./stage2/slimcc -std=c23 $(TEST_FLAGS) -c -o stage2/test/c23/$*.o test/c23/$*.c
 	$(CC) -std=c11 -pthread -Wno-psabi -no-pie -o $@ stage2/test/c23/$*.o -xc test/common
 
 test-stage2: $(TESTS:test/%=stage2/test/%) $(TESTS_C23:test/c23/%=stage2/test/c23/%)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,7 +33,7 @@ test-all: test test-stage2
 # Stage 2
 
 stage2/slimcc: $(OBJS:%=stage2/%)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	./slimcc -o $@ $^ $(LDFLAGS)
 
 stage2/%.o: slimcc %.c
 	mkdir -p stage2/test

--- a/codegen.c
+++ b/codegen.c
@@ -3202,7 +3202,7 @@ static void asm_constraint(AsmParam *ap, int x87_clobber) {
       case 't': fixed_reg(&reg, REG_X87_ST0, tok); continue;
       case 'u': fixed_reg(&reg, REG_X87_ST1, tok); continue;
       }
-      if (*p >= '0' && *p <= '9') {
+      if (Isdigit(*p)) {
         match_idx = strtoul(p, &p, 10);
         continue;
       }
@@ -3640,7 +3640,7 @@ static AsmParam *find_op(char *p, char **rest, Token *tok, bool is_label) {
         if (named_op(p, op->name->len, op->name->loc, rest))
           return op;
     }
-  } else if (*p >= '0' && *p <= '9') {
+  } else if (Isdigit(*p)) {
     unsigned long idx = strtoul(p, rest, 10);
     if (idx < asm_ops.cnt)
       return asm_ops.data[idx];
@@ -3662,7 +3662,7 @@ static void asm_body(Node *node) {
       p++;
       continue;
     }
-    if (*p == 'l' && (p[1] == '[' || (p[1] >= '0' && p[1] <= '9'))) {
+    if (*p == 'l' && (p[1] == '[' || Isdigit(p[1]))) {
       AsmParam *ap = find_op(p + 1, &p, node->asm_str, true);
       if (!ap->arg->unique_label)
         error_tok(ap->arg->tok, "not a label");
@@ -3685,7 +3685,7 @@ static void asm_body(Node *node) {
       mod = *p;
       p++;
     }
-    if (*p == '[' || (*p >= '0' && *p <= '9')) {
+    if (*p == '[' || Isdigit(*p)) {
       AsmParam *ap = find_op(p, &p, node->asm_str, false);
       char *punct = (mod == 'c') ? "" : "$";
 

--- a/main.c
+++ b/main.c
@@ -885,7 +885,7 @@ static FileType get_file_type(char *filename) {
   char *p = strstr(filename, ".so.");
   if (p) {
     p += 3;
-    while (isdigit(*p) || (*p == '.' && isdigit(p[1])))
+    while (Isdigit(*p) || (*p == '.' && Isdigit(p[1])))
       p++;
     if (!*p)
       return FILE_DSO;

--- a/main.c
+++ b/main.c
@@ -17,6 +17,7 @@ StdVer opt_std;
 
 static StringArray opt_include;
 bool opt_E;
+bool opt_enable_universal_char;
 static bool opt_P;
 static bool opt_M;
 static bool opt_MD;
@@ -413,6 +414,11 @@ static void parse_args(int argc, char **argv) {
       if (*argv[++i] != 'c')
         error("unknown c standard");
       set_std(strtoul(argv[i] + 1, NULL, 10));
+      continue;
+    }
+
+    if (!strcmp(argv[i], "-fenable-universal-char")) {
+      opt_enable_universal_char = true;
       continue;
     }
 

--- a/main.c
+++ b/main.c
@@ -471,6 +471,7 @@ static void parse_args(int argc, char **argv) {
         !strcmp(argv[i], "-m64") ||
         !strcmp(argv[i], "-mfpmath=sse") ||
         !strcmp(argv[i], "-mno-red-zone") ||
+        !strcmp(argv[i], "-no-pie") ||
         !strcmp(argv[i], "-pedantic") ||
         !strcmp(argv[i], "-w"))
       continue;

--- a/slimcc.h
+++ b/slimcc.h
@@ -22,6 +22,12 @@
 #define MAX(x, y) ((x) < (y) ? (y) : (x))
 #define MIN(x, y) ((x) < (y) ? (x) : (y))
 
+#define Ucast(c) (unsigned int)(unsigned char)(c)
+#define Inrange(c, x, y) ((Ucast(c) - Ucast(x)) <= (Ucast(y) - Ucast(x)))
+#define Isdigit(c) Inrange(c, '0', '9')
+#define Isalnum(c) (Inrange((c) | 0x20, 'a', 'z') || Isdigit(c))
+#define Isxdigit(c) (Isdigit(c) || Inrange((c) | 0x20, 'a', 'f'))
+
 #if defined(__GNUC__) && (__GNUC__ >= 3)
 #define FMTCHK(x,y) __attribute__((format(printf,(x),(y))))
 #define NORETURN __attribute__((noreturn))

--- a/slimcc.h
+++ b/slimcc.h
@@ -30,12 +30,16 @@
 #if defined(__GNUC__) && (__GNUC__ >= 3)
 #define FMTCHK(x,y) __attribute__((format(printf,(x),(y))))
 #define NORETURN __attribute__((noreturn))
+#define PACKED __attribute__((packed))
 #elif defined(__has_attribute)
 #if __has_attribute(format)
 #define FMTCHK(x,y) __attribute__((format(printf,(x),(y))))
 #endif
 #if __has_attribute(noreturn)
 #define NORETURN __attribute__((noreturn))
+#endif
+#if __has_attribute(packed)
+#define PACKED __attribute__((packed))
 #endif
 #endif
 
@@ -44,6 +48,9 @@
 #endif
 #ifndef NORETURN
 #define NORETURN
+#endif
+#ifndef PACKED
+#define PACKED
 #endif
 
 typedef struct Type Type;
@@ -141,7 +148,7 @@ struct Token {
   Token *origin;    // If this is expanded from a macro, the original token
   char *guard_file; // The path of a potentially include-guarded file
   Token *attr_next;
-};
+} PACKED;
 
 void error(char *fmt, ...) FMTCHK(1,2) NORETURN;
 void error_at(char *loc, char *fmt, ...) FMTCHK(2,3) NORETURN;

--- a/slimcc.h
+++ b/slimcc.h
@@ -72,6 +72,7 @@ typedef struct {
   HashEntry *buckets;
   int capacity;
   int used;
+  int mask;
 } HashMap;
 
 void *hashmap_get(HashMap *map, char *key);

--- a/slimcc.h
+++ b/slimcc.h
@@ -607,6 +607,7 @@ bool file_exists(char *path);
 
 extern StringArray include_paths;
 extern bool opt_E;
+extern bool opt_enable_universal_char;
 extern bool opt_fpic;
 extern bool opt_fcommon;
 extern bool opt_optimize;

--- a/slimcc.h
+++ b/slimcc.h
@@ -1,6 +1,5 @@
 #define _POSIX_C_SOURCE 200809L
 #include <assert.h>
-#include <ctype.h>
 #include <errno.h>
 #include <glob.h>
 #include <inttypes.h>

--- a/slimcc.h
+++ b/slimcc.h
@@ -11,7 +11,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -26,6 +25,7 @@
 #define Isdigit(c) Inrange(c, '0', '9')
 #define Isalnum(c) (Inrange((c) | 0x20, 'a', 'z') || Isdigit(c))
 #define Isxdigit(c) (Isdigit(c) || Inrange((c) | 0x20, 'a', 'f'))
+#define Casecmp(c, a) (((c) | 0x20) == a)
 
 #if defined(__GNUC__) && (__GNUC__ >= 3)
 #define FMTCHK(x,y) __attribute__((format(printf,(x),(y))))

--- a/tokenize.c
+++ b/tokenize.c
@@ -578,7 +578,7 @@ Token *tokenize(File *file, Token **end) {
 
     // Skip whitespace characters.
     if (*p == ' ' || *p == '\t' || *p =='\v' || *p == '\f') {
-      p++;
+      for (char c = *p; *(++p) == c;);
       has_space = true;
       continue;
     }

--- a/tokenize.c
+++ b/tokenize.c
@@ -225,11 +225,11 @@ static int read_escaped_char(char **new_pos, char *p) {
   if (*p == 'x') {
     // Read a hexadecimal number.
     p++;
-    if (!isxdigit(*p))
+    if (!Isxdigit(*p))
       error_at(p, "invalid hex escape sequence");
 
     int c = 0;
-    for (; isxdigit(*p); p++)
+    for (; Isxdigit(*p); p++)
       c = ((unsigned)c << 4) + from_hex(*p);
     *new_pos = p;
     return c;
@@ -381,7 +381,7 @@ static Token *new_pp_number(char *start, char *p) {
     if (*p == '.') {
       p++;
       continue;
-    } else if (*p == '\'' && isalnum(p[1])) {
+    } else if (*p == '\'' && Isalnum(p[1])) {
       p += 2;
       continue;
     } else if (p[0] && p[1] && strchr("eEpP", p[0]) && strchr("+-", p[1])) {
@@ -402,7 +402,7 @@ static bool convert_pp_int(Token *tok, char *loc, int len) {
 
   // Read a binary, octal, decimal or hexadecimal number.
   int base = 10;
-  if (!strncasecmp(p, "0x", 2) && isxdigit(p[2])) {
+  if (!strncasecmp(p, "0x", 2) && Isxdigit(p[2])) {
     p += 2;
     base = 16;
   } else if (!strncasecmp(p, "0b", 2) && (p[2] == '0' || p[2] == '1')) {
@@ -577,7 +577,7 @@ Token *tokenize(File *file, Token **end) {
     }
 
     // Skip whitespace characters.
-    if (isspace(*p)) {
+    if (*p == ' ' || *p == '\t' || *p =='\v' || *p == '\f') {
       p++;
       has_space = true;
       continue;
@@ -604,7 +604,7 @@ Token *tokenize(File *file, Token **end) {
 
     // Numeric literal
     char *p2 = (*p == '.') ? p + 1 : p;
-    if (isdigit(*p2)) {
+    if (Isdigit(*p2)) {
       cur = cur->next = new_pp_number(p, p2 + 1);
       p += cur->len;
       continue;
@@ -801,7 +801,7 @@ static void remove_backslash_newline(char *p) {
 static uint32_t read_universal_char(char *p, int len) {
   uint32_t c = 0;
   for (int i = 0; i < len; i++) {
-    if (!isxdigit(p[i]))
+    if (!Isxdigit(p[i]))
       return 0;
     c = (c << 4) | from_hex(p[i]);
   }

--- a/tokenize.c
+++ b/tokenize.c
@@ -789,48 +789,45 @@ File *new_file(char *name, int file_no, char *contents) {
 
 // Replaces \r or \r\n with \n.
 static void canonicalize_newline(char *p) {
-  int i = 0, j = 0;
+  char *first = strchr(p, '\r');
+  if (first) {
+    char *q = p = first;
 
-  while (p[i]) {
-    if (p[i] == '\r' && p[i + 1] == '\n') {
-      i += 2;
-      p[j++] = '\n';
-    } else if (p[i] == '\r') {
-      i++;
-      p[j++] = '\n';
-    } else {
-      p[j++] = p[i++];
+    while (*p) {
+      if (*p == '\r') {
+        *q++ = '\n';
+        p += (p[1] == '\n') + 1;
+        continue;
+      }
+      *q++ = *p++;
     }
-  }
 
-  p[j] = '\0';
+    *q = '\0';
+  }
 }
 
 // Removes backslashes followed by a newline.
 static void remove_backslash_newline(char *p) {
-  int i = 0, j = 0;
+  char *first = strchr(p, '\\');
+  if (first) {
+    char *q = p = first;
+    int n = 0;
 
-  // We want to keep the number of newline characters so that
-  // the logical line number matches the physical one.
-  // This counter maintain the number of newlines we have removed.
-  int n = 0;
-
-  while (p[i]) {
-    if (p[i] == '\\' && p[i + 1] == '\n') {
-      i += 2;
-      n++;
-    } else if (p[i] == '\n') {
-      p[j++] = p[i++];
-      for (; n > 0; n--)
-        p[j++] = '\n';
-    } else {
-      p[j++] = p[i++];
+    while (*p) {
+      if (*p == '\\' && p[1] == '\n') {
+        p += 2;
+        n++;
+        continue;
+      }
+      if (*p == '\n') {
+        for (; n > 0; n--)
+          *q++ = '\n';
+      }
+      *q++ = *p++;
     }
-  }
 
-  for (; n > 0; n--)
-    p[j++] = '\n';
-  p[j] = '\0';
+    *q = '\0';
+  }
 }
 
 static uint32_t read_universal_char(char *p, int len) {

--- a/tokenize.c
+++ b/tokenize.c
@@ -859,8 +859,6 @@ static void convert_universal_chars(char *p) {
         q += encode_utf8(q, c);
         continue;
       }
-    } else if (*p == '\\') {
-      *q++ = *p++;
     }
     *q++ = *p++;
   }

--- a/tokenize.c
+++ b/tokenize.c
@@ -874,7 +874,9 @@ Token *tokenize_file(char *path, Token **end) {
 
   canonicalize_newline(p);
   remove_backslash_newline(p);
-  convert_universal_chars(p);
+
+  if (opt_enable_universal_char)
+    convert_universal_chars(p);
 
   return tokenize(add_input_file(path, p, false), end);
 }

--- a/tokenize.c
+++ b/tokenize.c
@@ -86,7 +86,7 @@ void warn_tok(Token *tok, char *fmt, ...) {
 
 // Consumes the current token if it matches `op`.
 bool equal(Token *tok, char *op) {
-  return strlen(op) == tok->len && !memcmp(tok->loc, op, tok->len);
+  return !strncmp(tok->loc, op, tok->len) && op[tok->len] == '\0';
 }
 
 bool equal_ext(Token *tok, char *op) {

--- a/tokenize.c
+++ b/tokenize.c
@@ -143,9 +143,9 @@ static int read_ident(char *start) {
 }
 
 static int from_hex(char c) {
-  if ('0' <= c && c <= '9')
+  if (Inrange(c, '0', '9'))
     return c - '0';
-  if ('a' <= c && c <= 'f')
+  if (Inrange(c, 'a', 'f'))
     return c - 'a' + 10;
   return c - 'A' + 10;
 }
@@ -210,12 +210,12 @@ TokenKind ident_keyword(Token *tok) {
 }
 
 static int read_escaped_char(char **new_pos, char *p) {
-  if ('0' <= *p && *p <= '7') {
+  if (Inrange(*p, '0', '7')) {
     // Read an octal number.
     int c = *p++ - '0';
-    if ('0' <= *p && *p <= '7') {
+    if (Inrange(*p, '0', '7')) {
       c = (c << 3) + (*p++ - '0');
-      if ('0' <= *p && *p <= '7')
+      if (Inrange(*p, '0', '7'))
         c = (c << 3) + (*p++ - '0');
     }
     *new_pos = p;


### PR DESCRIPTION
Using strncmp() instead of strlen() combined with memcmp() not only reduces the overhead of multiple function calls but also takes advantage of compiler optimizations, such as implicit function inlining.