### PR TITLE
Expand macro only when preprocessor token is identifier

### DIFF
--- a/preprocess.c
+++ b/preprocess.c
@@ -1077,7 +1077,7 @@ static Token *preprocess2(Token *tok) {
 
   for (; tok->kind != TK_EOF; pop_macro_lock(tok)) {
     // If it is a macro, expand it.
-    if (expand_macro(&tok, tok))
+    if (tok->kind == TK_IDENT && expand_macro(&tok, tok))
       continue;
 
     if (is_hash(tok) && !locked_macros) {


### PR DESCRIPTION
In 'preprocess2' function, 'expand_macro' was called multiple times, some of which were unnecessary. This change ensures that 'expand_macro' is called only when the preprocessor token is an identifier.