### PR TITLE
Disallow 'defined' as a macro name

### DIFF
--- a/preprocess.c
+++ b/preprocess.c
@@ -421,6 +421,10 @@ static MacroParam *read_macro_params(Token **rest, Token *tok, Token **va_args_n
 static void read_macro_definition(Token **rest, Token *tok) {
   if (tok->kind != TK_IDENT)
     error_tok(tok, "macro name must be an identifier");
+
+  if (equal(tok, "defined"))
+    error_tok(tok, "cannot be used as a macro name");
+
   char *name = strndup(tok->loc, tok->len);
   tok = tok->next;
 


### PR DESCRIPTION
While 'defined' is not a keyword in the C programming language, it is a special operator recognized by the preprocessor when used within the context of a preprocessor directive.

This commit enforces an error when 'defined' is used as a macro name:
```
  #define defined 1
          ^ cannot be used as a macro name
```