### PR TITLE
Specialize (type) keywords as independent token kinds

### DIFF
--- a/slimcc.h
+++ b/slimcc.h
@@ -99,12 +99,83 @@ char *format(char *fmt, ...) FMTCHK(1,2);
 // tokenize.c
 //
 
+#define equal_kind(tk, tk_kind) (tk->kind == tk_kind)
+#define is_tykw(tk_kind) ((tk_kind >= TK_VOID && tk_kind <= TK___VOLATILE__) || \
+   tk_kind == TK_TYPEOF || (tk_kind >= TK_ALIGNAS && tk_kind <= TK_TYPEOF_UNQUAL))
+
 // Token
 typedef enum {
   TK_IDENT,   // Identifiers
   TK_PUNCT,   // Punctuators
-  TK_KEYWORD, // Keywords
-  TK_TYPEKW,  // Keywords
+  /* Keywords */
+  TK_RETURN,
+  TK_IF,
+  TK_ELSE,
+  TK_FOR,
+  TK_WHILE,
+  TK_DO,
+  TK_GOTO,
+  TK_BREAK,
+  TK_CONTINUE,
+  TK_SWITCH,
+  TK_CASE,
+  TK_DEFAULT,
+  TK__ALIGNOF,
+  TK_SIZEOF,
+  TK__ASM,
+  TK___ASM__,
+  TK__STATIC_ASSERT,
+  TK__DEFER,
+  /* Type Keywords */
+  TK_VOID,
+  TK__BOOL,
+  TK_CHAR,
+  TK_SHORT,
+  TK_INT,
+  TK_LONG,
+  TK_STRUCT,
+  TK_UNION,
+  TK_TYPEDEF,
+  TK_ENUM,
+  TK_STATIC,
+  TK_EXTERN,
+  TK__ALIGNAS,
+  TK_SIGNED,
+  TK_UNSIGNED,
+  TK_CONST,
+  TK_AUTO,
+  TK_REGISTER,
+  TK_RESTRICT,
+  TK___RESTRICT,
+  TK___RESTRICT__,
+  TK__NORETURN,
+  TK_FLOAT,
+  TK_DOUBLE,
+  TK_INLINE,
+  TK___AUTO_TYPE,
+  TK__THREAD_LOCAL,
+  TK___THREAD,
+  TK__ATOMIC,
+  TK___TYPEOF,
+  TK___TYPEOF__,
+  TK_VOLATILE,
+  TK___VOLATILE,
+  TK___VOLATILE__,
+  /* NONE Keywords */
+  TK_ASM,
+  /* NONE / C23+ Type Keywords */
+  TK_TYPEOF,
+  /* C23 Keywords */
+  TK_ALIGNOF,
+  TK_FALSE,
+  TK_TRUE,
+  TK_STATIC_ASSERT,
+  /* C23 Type Keyowords */
+  TK_ALIGNAS,
+  TK_BOOL,
+  TK_CONSTEXPR,
+  TK_THREAD_LOCAL,
+  TK_TYPEOF_UNQUAL,
   TK_STR,     // String literals
   TK_NUM,     // Numeric literals
   TK_PP_NUM,  // Preprocessing numbers

--- a/tokenize.c
+++ b/tokenize.c
@@ -211,7 +211,7 @@ TokenKind ident_keyword(Token *tok) {
       "_Static_assert", "_Defer"
     };
     for (int i = 0; i < sizeof(kw) / sizeof(*kw); i++)
-      hashmap_put(&map, kw[i], (void *)TK_KEYWORD);
+      hashmap_put(&map, kw[i], (void *)(intptr_t)(TK_RETURN + i));
 
     static char *ty_kw[] = {
       "void", "_Bool", "char", "short", "int", "long", "struct", "union",
@@ -222,23 +222,23 @@ TokenKind ident_keyword(Token *tok) {
       "volatile", "__volatile", "__volatile__"
     };
     for (int i = 0; i < sizeof(ty_kw) / sizeof(*ty_kw); i++)
-      hashmap_put(&map, ty_kw[i], (void *)TK_TYPEKW);
+      hashmap_put(&map, ty_kw[i], (void *)(intptr_t)(TK_VOID + i));
 
     if (opt_std == STD_NONE)
-      hashmap_put(&map, "asm", (void *)TK_KEYWORD);
+      hashmap_put(&map, "asm", (void *)TK_ASM);
     if (opt_std == STD_NONE || opt_std >= STD_C23)
-      hashmap_put(&map, "typeof", (void *)TK_TYPEKW);
+      hashmap_put(&map, "typeof", (void *)TK_TYPEOF);
     if (opt_std >= STD_C23) {
-      hashmap_put(&map, "alignof", (void *)TK_KEYWORD);
-      hashmap_put(&map, "false", (void *)TK_KEYWORD);
-      hashmap_put(&map, "true", (void *)TK_KEYWORD);
-      hashmap_put(&map, "static_assert", (void *)TK_KEYWORD);
+      hashmap_put(&map, "alignof", (void *)TK_ALIGNOF);
+      hashmap_put(&map, "false", (void *)TK_FALSE);
+      hashmap_put(&map, "true", (void *)TK_TRUE);
+      hashmap_put(&map, "static_assert", (void *)TK_STATIC_ASSERT);
 
-      hashmap_put(&map, "alignas", (void *)TK_TYPEKW);
-      hashmap_put(&map, "bool", (void *)TK_TYPEKW);
-      hashmap_put(&map, "constexpr", (void *)TK_TYPEKW);
-      hashmap_put(&map, "thread_local", (void *)TK_TYPEKW);
-      hashmap_put(&map, "typeof_unqual", (void *)TK_TYPEKW);
+      hashmap_put(&map, "alignas", (void *)TK_ALIGNAS);
+      hashmap_put(&map, "bool", (void *)TK_BOOL);
+      hashmap_put(&map, "constexpr", (void *)TK_CONSTEXPR);
+      hashmap_put(&map, "thread_local", (void *)TK_THREAD_LOCAL);
+      hashmap_put(&map, "typeof_unqual", (void *)TK_TYPEOF_UNQUAL);
     }
   }
   void *val = hashmap_get2(&map, tok->loc, tok->len);


### PR DESCRIPTION
This PR specializes every keyword tokens into independent kinds, reduces each keyword token string comparison to once per compilation, in other words, keywords will be identified in tokenization phase.