### PR TITLE
Disallow splitting colons in vendor attributes

### DIFF
--- a/preprocess.c
+++ b/preprocess.c
@@ -2008,10 +2008,10 @@ static void filter_attr(Token *tok, Token **lst, bool is_bracket) {
 
     Token *vendor = NULL;
     if (tok->kind == TK_IDENT && equal(tok->next, ":")) {
+      vendor = tok;
       Token *first_colon = tok->next;
       Token *second_colon = tok->next->next;
       
-      vendor = tok;
       tok = skip(tok->next->next, ":");
       
       if(first_colon->loc + 1 != second_colon->loc)


### PR DESCRIPTION
Hi. I'm working on a fork of slimcc to implement my idea of namespaces in C.

And so I noticed that slimcc doesn't treat `::` as a single token.

So code like this is  allowed
```C
[[gnu : : aligned]] typedef char c;;
```

I made a new branch with a simple fix, all I do is make sure the second colon is directly after the first.

It's a bit hacky, treating `::` as its own token is probably a better solution. But when I tried that it broke another part of the code, namely GNU volatile asm blocks. Since it could have `::` or `:::` (empty inputs, outputs, and clobbers)