### PR TITLE
Allowing -std=c2y flag, as an alias to c23

### DIFF
--- a/main.c
+++ b/main.c
@@ -184,6 +184,13 @@ static bool set_true(char *p, char *str, bool *opt) {
 }
 
 static void set_std(bool is_iso, char *arg) {
+  if(strcmp(arg, "2y") == 0)
+  {
+    is_iso_std = true;
+    opt_std = STD_C23;
+    return;
+  }
+  
   char *end;
   int val = strtoul(arg, &end, 10);
 

--- a/main.c
+++ b/main.c
@@ -186,7 +186,7 @@ static bool set_true(char *p, char *str, bool *opt) {
 static void set_std(bool is_iso, char *arg) {
   if(strcmp(arg, "2y") == 0)
   {
-    is_iso_std = true;
+    is_iso_std = is_iso;
     opt_std = STD_C23;
     return;
   }


### PR DESCRIPTION
Simple change. Ideally the -std=c2y flag should enable c2y extensions that slimcc implements, and -std=c23 should disable them. But this is fine.