### PR TITLE
String interpolation idea

### DIFF
--- a/preprocess.c
+++ b/preprocess.c
@@ -1981,113 +1981,37 @@ static Token *interp_literal_count_macro(Token *start)
   return new_num_token(counter, start, tok);
 }
 
-static Token *interp_at_macro(Token *start)
-{
-  Token *tok = skip(start->next, "(");
-
-  if(tok->kind != TK_ISTR)
-    error_tok(start, "not an interpolated string");
-
-  Token *itok = tok;
-  tok = skip(tok->next, ",");
-
-  Token *idx_tok = read_macro_arg_one(&tok, tok, false);
-
-  int64_t idx = eval_const_expr(idx_tok);
-
-  Token *it = itok->interp_next;
-  if(it == NULL)
-    error_tok(start, "interpolate string does not contain any interpolations");
-
-  int64_t count = idx;
-  while(count--)
-  {
-    it = it->interp_next;
-    if(it == NULL)
-      error_tok(start, "interpolate index %d out of bounds for %.*s", (int)idx, itok->len, itok->loc);
-  }
-
-  tok = skip(tok, ")");
-
-  pop_macro_lock_until(start, tok);
-
-  if(it->kind == TK_EOF)
-    return tok;
-
-  Token *ret = copy_token(it);
-  Token *cur = ret;
-  for(Token *t = it->next; t->kind != TK_EOF; t = t->next)
-    cur = cur->next = copy_token(t);
-  cur->next = tok;
-  return ret;
-}
-
-static Token *interp_literal_at_macro(Token *start)
-{
-  Token *tok = skip(start->next, "(");
-
-  if(tok->kind != TK_ISTR)
-    error_tok(start, "not an interpolated string");
-
-  Token *itok = tok;
-  tok = skip(tok->next, ",");
-
-  Token *idx_tok = read_macro_arg_one(&tok, tok, false);
-  int64_t idx = eval_const_expr(idx_tok);
-
-  Token *it = itok->interp_str_next;
-  assert(it); // it being NULL makes no sense
-
-  int64_t count = idx;
-  while(count--)
-  {
-    it = it->interp_str_next;
-    if(it == NULL)
-      error_tok(start, "literal index %d out of bounds for %.*s", (int)idx, itok->len, itok->loc);
-  }
-
-  tok = skip(tok, ")");
-
-  char *quoted = strndup(it->loc, it->len);
-  quoted[0] = '"';
-  quoted[it->len - 1] = '"';
-
-  pop_macro_lock_until(start, tok);
-  Token *ret = make_token(quoted, it, tok);
-  ret->loc = quoted;
-
-  return ret;
-}
-
 static Token *interp_list_macro(Token *start)
 {
   Token *tok = skip(start->next, "(");
-  
+
   Token *itok = tok;
+
   if(itok->kind != TK_ISTR)
     error_tok(start, "not an interpolated string");
-  
+
+  tok = tok->next;
+  tok = skip(tok, ")");
+
   Token *it = itok->interp_next;
-  
-  Token *arg2 = skip(itok->next, ",");
-  
-  Token *macro = split_paren(&tok, arg2);
-  
+
   pop_macro_lock_until(start, tok);
-  
+
   if(it == NULL || it->kind == TK_EOF)
     return tok;
-  
+
   Token head = {0};
   Token *cur = &head;
   while(it && it->kind != TK_EOF)
   {
-    for(Token *t = macro; t->kind != TK_EOF; t = t->next)
-      cur = cur->next = copy_token(t);
     cur = cur->next = make_token("(", tok, NULL);
     for(Token *t = it; t->kind != TK_EOF; t = t->next)
       cur = cur->next = copy_token(t);
     cur = cur->next = make_token(")", tok, NULL);
+
+    if(it->interp_next && it->interp_next->kind != TK_EOF)
+      cur = cur->next = make_token(",", tok, NULL);
+
     it = it->interp_next;
   }
   cur->next = tok;
@@ -2097,36 +2021,32 @@ static Token *interp_list_macro(Token *start)
 static Token *interp_literal_list_macro(Token *start)
 {
   Token *tok = skip(start->next, "(");
-  
+
   Token *itok = tok;
   if(itok->kind != TK_ISTR)
     error_tok(start, "not an interpolated string");
-  
+
+  tok = tok->next;
+  tok = skip(tok, ")");
+
   Token *it = itok->interp_str_next;
-  
-  Token *arg2 = skip(itok->next, ",");
-  
-  Token *macro = split_paren(&tok, arg2);
-  
+
   pop_macro_lock_until(start, tok);
   
   if(it == NULL || it->kind == TK_EOF)
     return tok;
-  
+
   Token head = {0};
   Token *cur = &head;
   while(it && it->kind != TK_EOF)
   {
-    for(Token *t = macro; t->kind != TK_EOF; t = t->next)
-      cur = cur->next = copy_token(t);
-    
-    cur = cur->next = make_token("(", tok, NULL);
-    
     char *quoted = strndup(it->loc, it->len);
     quoted[0] = quoted[it->len - 1] = '"';
-    
+
     cur = cur->next = make_token(quoted, it, NULL);
-    cur = cur->next = make_token(")", tok, NULL);
+
+    if(it->interp_str_next && it->interp_str_next->kind != TK_EOF)
+      cur = cur->next = make_token(",", tok, NULL);
     it = it->interp_str_next;
   }
   cur->next = tok;
@@ -2187,8 +2107,6 @@ void init_macros(void) {
 
   add_builtin("__INTERP_COUNT__", interp_count_macro, true);
   add_builtin("__INTERP_LITERAL_COUNT__", interp_literal_count_macro, true);
-  add_builtin("__INTERP_AT__", interp_at_macro, true);
-  add_builtin("__INTERP_LITERAL_AT__", interp_literal_at_macro, true);
   add_builtin("__INTERP_LIST__", interp_list_macro, true);
   add_builtin("__INTERP_LITERAL_LIST__", interp_literal_list_macro, true);
 }

--- a/preprocess.c
+++ b/preprocess.c
@@ -1458,17 +1458,6 @@ void preprocess2(Token *tok, Token **cur) {
     error_tok(cond->tok, "unterminated conditional directive");
 
   if (start_m != locked_macros) {
-    Macro *m = locked_macros;
-    while (m != start_m) {
-      fprintf(stderr, "unbalanced macro lock, stop_tok kind=%d at %s:%d, is_locked=%d, macro body starts: %.*s\n",
-              m->stop_tok->kind,
-              m->stop_tok->file ? m->stop_tok->file->name : "<null>",
-              m->stop_tok->line_no,
-              m->is_locked,
-              m->body ? m->body->len : 0,
-              m->body ? m->body->loc : "");
-      m = m->locked_next;
-    }
     internal_error();
   }
 }
@@ -1967,9 +1956,28 @@ static Token *interp_count_macro(Token *start)
   
   tok = skip(tok->next, ")");
   
-  fprintf(stderr, "pop_macro_lock_until: start=%p stop=%p locked_macros=%p locked_macros->stop_tok=%p\n",
-          (void*)start, (void*)tok, (void*)locked_macros,
-          locked_macros ? (void*)locked_macros->stop_tok : NULL);
+  pop_macro_lock_until(start, tok);
+  return new_num_token(counter, start, tok);
+}
+
+static Token *interp_literal_count_macro(Token *start)
+{
+  Token *tok = skip(start->next, "(");
+  
+  if(tok->kind != TK_ISTR)
+    error_tok(start, "not an interpolated string");
+  
+  int counter = 0;
+  Token *lit = tok->interp_str_next;
+  
+  while(lit)
+  {
+    counter += 1;
+    lit = lit->interp_str_next;
+  }
+  
+  tok = skip(tok->next, ")");
+  
   pop_macro_lock_until(start, tok);
   return new_num_token(counter, start, tok);
 }
@@ -2001,12 +2009,17 @@ static Token *interp_at_macro(Token *start)
   }
   
   tok = skip(tok, ")");
-  
-  fprintf(stderr, "pop_macro_lock_until: start=%p stop=%p locked_macros=%p locked_macros->stop_tok=%p\n",
-          (void*)start, (void*)tok, (void*)locked_macros,
-          locked_macros ? (void*)locked_macros->stop_tok : NULL);
+
   pop_macro_lock_until(start, tok);
-  Token *ret = make_token(strndup(it->loc, it->len), it, tok);
+  
+  if(it->kind == TK_EOF)
+    return tok;
+  
+  Token *ret = copy_token(it);
+  Token *cur = ret;
+  for(Token *t = it->next; t->kind != TK_EOF; t = t->next)
+    cur = cur->next = copy_token(t);
+  cur->next = tok;
   return ret;
 }
 
@@ -2101,6 +2114,7 @@ void init_macros(void) {
   add_builtin("__has_embed", has_embed_macro, true);
   
   add_builtin("__INTERP_COUNT__", interp_count_macro, true);
+  add_builtin("__INTERP_LITERAL_COUNT__", interp_literal_count_macro, true);
   add_builtin("__INTERP_AT__", interp_at_macro, true);
   add_builtin("__INTERP_LITERAL_AT__", interp_literal_at_macro, true);
 }

--- a/preprocess.c
+++ b/preprocess.c
@@ -1937,31 +1937,33 @@ static Token *has_extension_macro(Token *start) {
   return new_bool_int_token(has_it, start, tok);
 }
 
-static void iter_interp_str(const char *str, int len, void(*on_found_interp)(const char *, int len, void *arg), void *arg)
+static void iter_interp_str(Token *tok, void(*on_found_interp)(Token *start, Token *end, void *arg), void *arg)
 {
+  const char *str = tok->loc + 1;
+  int len = tok->len - 1; // len may be incorrect because string literals are allowed to exist in interpolated string...
+  // the only solution is to tokenize them properly TK_ISTR
+  
   for(int i = 0 ; i < len - 1 ; i++)
   {
-    if(str[i] == '{')
+    if(str[i] == '$')
     {
       if(str[i + 1] == '{')
       {
-        i++;
+        int braces_open = 1;
+        Token *end;
+        Token *start = tokenize_cb(new_file("<built-in>", str + i + 2), NULL, &end, stop_on_unbalanced_close_curly_brace, &braces_open);
+        
+        on_found_interp(start, end, arg);
+        
+        str = end->loc + end->len;
+      }
+      else if(str[i + 1] == '$')
+      {
+        i += 1;
       }
       else
       {
-        // probably should tokenize_until_unbalanced_closing_curly_brace
-        int interp_len = 0;
-        int single_quote = 0; // open brace adds 1
-        int double_quote = 0;
-        while(balance)
-        {
-          if(str[i] == '{')
-            balance += 1;
-          else if(str[i] == '}')
-            balance -= 1;
-        }
-        
-        on_found_interp(str, );
+        error_tok(tok, "bad interpolate string");
       }
     }
   }
@@ -1970,13 +1972,13 @@ static void iter_interp_str(const char *str, int len, void(*on_found_interp)(con
 static Token *interp_count_macro(Token *start)
 {
   Token *tok = skip(start, "(");
+    
   if(!equal(tok, "$"))
-  {
     return new_num_token(0, start, tok);
-  }
+  
   tok = skip(tok, "$");
   if(tok->kind != TK_STR)
-    return new_eof(start);
+    error_tok(tok, "expected a string literal");
   
   const char *str = tok->loc + 1; // skip first quote
   int len = tok->len - 2; // don't include first and last quotes

--- a/preprocess.c
+++ b/preprocess.c
@@ -1987,8 +1987,8 @@ static Token *interp_list_macro(Token *start)
 
   Token *itok = tok;
 
-  if(itok->kind != TK_ISTR)
-    error_tok(start, "not an interpolated string");
+  if(itok->kind != TK_ISTR && itok->kind != TK_STR)
+    error_tok(start, "expected a string");
 
   tok = tok->next;
   tok = skip(tok, ")");
@@ -2023,8 +2023,8 @@ static Token *interp_literal_list_macro(Token *start)
   Token *tok = skip(start->next, "(");
 
   Token *itok = tok;
-  if(itok->kind != TK_ISTR)
-    error_tok(start, "not an interpolated string");
+  if(itok->kind != TK_ISTR && itok->kind != TK_STR)
+    error_tok(start, "expected a string");
 
   tok = tok->next;
   tok = skip(tok, ")");
@@ -2033,7 +2033,13 @@ static Token *interp_literal_list_macro(Token *start)
 
   pop_macro_lock_until(start, tok);
   
-  if(it == NULL || it->kind == TK_EOF)
+  if(itok->kind == TK_STR)
+  {
+     Token *cur = copy_token(itok);
+     cur->next = tok;
+     return cur;
+  }
+  else if(it == NULL || it->kind == TK_EOF)
     return tok;
 
   Token head = {0};

--- a/preprocess.c
+++ b/preprocess.c
@@ -807,13 +807,13 @@ static Token *subst(Token *tok, MacroContext *ctx) {
       MacroArg *start_arg = find_arg(&tok, tok, ctx);
       Token *start_tok = read_const_expr(start_arg->tok);
       int64_t start = eval_const_expr(start_tok);
-      
+
       tok = skip(tok, ",");
-      
+
       MacroArg *len_arg = find_arg(&tok, tok, ctx);
       Token *len_tok = read_const_expr(len_arg->tok);
       int64_t len = eval_const_expr(len_tok);
-      
+
       if (start <= 0)
       {
         error_tok(start_tok, "__VA_SLICE__ Non-positive start");
@@ -822,13 +822,13 @@ static Token *subst(Token *tok, MacroContext *ctx) {
       {
         error_tok(start_tok, "__VA_SLICE__ Negative length");
       }
-      
+
       MacroArg *vaarg;
       if (!has_non_empty_va_arg(ctx, &vaarg))
       {
         continue;
       }
-      
+
       Token *arg_iter = vaarg->tok;
       int level = 0;
       for(int64_t i = 1 ; i < start && arg_iter->kind != TK_EOF ; i++)
@@ -845,13 +845,13 @@ static Token *subst(Token *tok, MacroContext *ctx) {
           }
           arg_iter = arg_iter->next;
         }
-        
+
         if(arg_iter->kind != TK_EOF)
         {
           arg_iter = arg_iter->next; // skip comma
         }
       }
-      
+
       int64_t len_it = 0;
       level = 0;
       while(arg_iter->kind != TK_EOF && len_it < len)
@@ -866,7 +866,7 @@ static Token *subst(Token *tok, MacroContext *ctx) {
           {
             level -= 1;
           }
-          
+
           cur = cur->next = copy_token(arg_iter);
           arg_iter = arg_iter->next;
         }
@@ -877,14 +877,14 @@ static Token *subst(Token *tok, MacroContext *ctx) {
           arg_iter = arg_iter->next; // comma
         }
       }
-      
+
       tok = tok->next; // skip final )
       continue;
     }
     if(equal(tok, "__VA_COUNT_INTERNAL__") && consume(&tok, tok->next, "("))
     {
       tok = skip(tok, ")");
-      
+
       MacroArg *vaarg;
       if (!has_non_empty_va_arg(ctx, &vaarg))
       {
@@ -910,12 +910,12 @@ static Token *subst(Token *tok, MacroContext *ctx) {
         }
         if(arg_iter->kind != TK_EOF)
           arg_iter = arg_iter->next; // skip comma
-        
+
         count += 1;
       }
-      
+
       cur = cur->next = new_num_token(count, tok, tok->next);
-      
+
       continue;
     }
     if(equal(tok, "__REPEAT_INTERNAL__") && consume(&tok, tok->next, "("))
@@ -923,11 +923,11 @@ static Token *subst(Token *tok, MacroContext *ctx) {
       MacroArg *n_arg = find_arg(&tok, tok, ctx);
       Token *n_tok = read_const_expr(n_arg->tok);
       int64_t n = eval_const_expr(n_tok);
-      
+
       tok = skip(tok, ")");
-      
+
       MacroArg *vaarg = &ctx->args[ctx->m->arg_cnt - 1];
-      
+
       int level = 0;
       for(int64_t i = 0; i < n ; i++)
       {
@@ -942,15 +942,15 @@ static Token *subst(Token *tok, MacroContext *ctx) {
           {
             level -= 1;
           }
-          
+
           cur = cur->next = copy_token(arg_iter);
           arg_iter = arg_iter->next;
         }
       }
-      
+
       continue;
     }
-    
+
     if (equal(tok, "__VA_TAIL__") && consume(&tok, tok->next, "(")) {
       Macro *tail_m = NULL;
       Token *rparen = NULL;
@@ -1457,9 +1457,9 @@ void preprocess2(Token *tok, Token **cur) {
   if (get_cond_incl(&cond))
     error_tok(cond->tok, "unterminated conditional directive");
 
-  if (start_m != locked_macros) {
+  if (start_m != locked_macros)
     internal_error();
-  }
+
 }
 
 static Token *pass_line(Token **cur, Token *tok) {
@@ -1941,21 +1941,21 @@ static Token *has_extension_macro(Token *start) {
 static Token *interp_count_macro(Token *start)
 {
   Token *tok = skip(start->next, "(");
-  
+
   if(tok->kind != TK_ISTR)
     error_tok(start, "not an interpolated string");
-  
+
   int counter = 0;
   Token *interp = tok->interp_next;
-  
+
   while(interp)
   {
     counter += 1;
     interp = interp->interp_next;
   }
-  
+
   tok = skip(tok->next, ")");
-  
+
   pop_macro_lock_until(start, tok);
   return new_num_token(counter, start, tok);
 }
@@ -1963,21 +1963,21 @@ static Token *interp_count_macro(Token *start)
 static Token *interp_literal_count_macro(Token *start)
 {
   Token *tok = skip(start->next, "(");
-  
+
   if(tok->kind != TK_ISTR)
     error_tok(start, "not an interpolated string");
-  
+
   int counter = 0;
   Token *lit = tok->interp_str_next;
-  
+
   while(lit)
   {
     counter += 1;
     lit = lit->interp_str_next;
   }
-  
+
   tok = skip(tok->next, ")");
-  
+
   pop_macro_lock_until(start, tok);
   return new_num_token(counter, start, tok);
 }
@@ -1985,21 +1985,21 @@ static Token *interp_literal_count_macro(Token *start)
 static Token *interp_at_macro(Token *start)
 {
   Token *tok = skip(start->next, "(");
-  
+
   if(tok->kind != TK_ISTR)
     error_tok(start, "not an interpolated string");
-  
+
   Token *itok = tok;
   tok = skip(tok->next, ",");
-  
+
   Token *idx_tok = read_macro_arg_one(&tok, tok, false);
-  
+
   int64_t idx = eval_const_expr(idx_tok);
-  
+
   Token *it = itok->interp_next;
   if(it == NULL)
     error_tok(start, "interpolate string does not contain any interpolations");
-  
+
   int64_t count = idx;
   while(count--)
   {
@@ -2007,14 +2007,14 @@ static Token *interp_at_macro(Token *start)
     if(it == NULL)
       error_tok(start, "interpolate index %d out of bounds for %.*s", (int)idx, itok->len, itok->loc);
   }
-  
+
   tok = skip(tok, ")");
 
   pop_macro_lock_until(start, tok);
-  
+
   if(it->kind == TK_EOF)
     return tok;
-  
+
   Token *ret = copy_token(it);
   Token *cur = ret;
   for(Token *t = it->next; t->kind != TK_EOF; t = t->next)
@@ -2026,19 +2026,19 @@ static Token *interp_at_macro(Token *start)
 static Token *interp_literal_at_macro(Token *start)
 {
   Token *tok = skip(start->next, "(");
-  
+
   if(tok->kind != TK_ISTR)
     error_tok(start, "not an interpolated string");
-  
+
   Token *itok = tok;
   tok = skip(tok->next, ",");
-  
+
   Token *idx_tok = read_macro_arg_one(&tok, tok, false);
   int64_t idx = eval_const_expr(idx_tok);
-  
+
   Token *it = itok->interp_str_next;
   assert(it); // it being NULL makes no sense
-  
+
   int64_t count = idx;
   while(count--)
   {
@@ -2046,13 +2046,13 @@ static Token *interp_literal_at_macro(Token *start)
     if(it == NULL)
       error_tok(start, "literal index %d out of bounds for %.*s", (int)idx, itok->len, itok->loc);
   }
-  
+
   tok = skip(tok, ")");
-  
+
   char *quoted = strndup(it->loc, it->len);
   quoted[0] = '"';
   quoted[it->len - 1] = '"';
-  
+
   pop_macro_lock_until(start, tok);
   Token *ret = make_token(quoted, it, tok);
   ret->loc = quoted;
@@ -2112,7 +2112,7 @@ void init_macros(void) {
   add_builtin("__has_include", has_include_macro, true);
   add_builtin("__has_include_next", has_include_next_macro, true);
   add_builtin("__has_embed", has_embed_macro, true);
-  
+
   add_builtin("__INTERP_COUNT__", interp_count_macro, true);
   add_builtin("__INTERP_LITERAL_COUNT__", interp_literal_count_macro, true);
   add_builtin("__INTERP_AT__", interp_at_macro, true);

--- a/preprocess.c
+++ b/preprocess.c
@@ -1459,7 +1459,6 @@ void preprocess2(Token *tok, Token **cur) {
 
   if (start_m != locked_macros)
     internal_error();
-
 }
 
 static Token *pass_line(Token **cur, Token *tok) {

--- a/preprocess.c
+++ b/preprocess.c
@@ -1457,8 +1457,20 @@ void preprocess2(Token *tok, Token **cur) {
   if (get_cond_incl(&cond))
     error_tok(cond->tok, "unterminated conditional directive");
 
-  if (start_m != locked_macros)
+  if (start_m != locked_macros) {
+    Macro *m = locked_macros;
+    while (m != start_m) {
+      fprintf(stderr, "unbalanced macro lock, stop_tok kind=%d at %s:%d, is_locked=%d, macro body starts: %.*s\n",
+              m->stop_tok->kind,
+              m->stop_tok->file ? m->stop_tok->file->name : "<null>",
+              m->stop_tok->line_no,
+              m->is_locked,
+              m->body ? m->body->len : 0,
+              m->body ? m->body->loc : "");
+      m = m->locked_next;
+    }
     internal_error();
+  }
 }
 
 static Token *pass_line(Token **cur, Token *tok) {
@@ -1937,78 +1949,102 @@ static Token *has_extension_macro(Token *start) {
   return new_bool_int_token(has_it, start, tok);
 }
 
-static void iter_interp_str(Token *tok, void(*on_found_interp)(Token *start, Token *end, void *arg), void *arg)
-{
-  const char *str = tok->loc + 1;
-  int len = tok->len - 1; // len may be incorrect because string literals are allowed to exist in interpolated string...
-  // the only solution is to tokenize them properly TK_ISTR
-  
-  for(int i = 0 ; i < len - 1 ; i++)
-  {
-    if(str[i] == '$')
-    {
-      if(str[i + 1] == '{')
-      {
-        int braces_open = 1;
-        Token *end;
-        Token *start = tokenize_cb(new_file("<built-in>", str + i + 2), NULL, &end, stop_on_unbalanced_close_curly_brace, &braces_open);
-        
-        on_found_interp(start, end, arg);
-        
-        str = end->loc + end->len;
-      }
-      else if(str[i + 1] == '$')
-      {
-        i += 1;
-      }
-      else
-      {
-        error_tok(tok, "bad interpolate string");
-      }
-    }
-  }
-}
-
 static Token *interp_count_macro(Token *start)
 {
-  Token *tok = skip(start, "(");
-    
-  if(!equal(tok, "$"))
-    return new_num_token(0, start, tok);
+  Token *tok = skip(start->next, "(");
   
-  tok = skip(tok, "$");
-  if(tok->kind != TK_STR)
-    error_tok(tok, "expected a string literal");
+  if(tok->kind != TK_ISTR)
+    error_tok(start, "not an interpolated string");
   
-  const char *str = tok->loc + 1; // skip first quote
-  int len = tok->len - 2; // don't include first and last quotes
+  int counter = 0;
+  Token *interp = tok->interp_next;
   
-  int count = 0;
-  for(int i = 0 ; i < len - 1 ; i++)
+  while(interp)
   {
-    if(str[i] == '{')
-    {
-      if(str[i + 1] == '{')
-      {
-        i++;
-      }
-      else
-      {
-        count += 1;
-        
-      }
-    }
+    counter += 1;
+    interp = interp->interp_next;
   }
+  
+  tok = skip(tok->next, ")");
+  
+  fprintf(stderr, "pop_macro_lock_until: start=%p stop=%p locked_macros=%p locked_macros->stop_tok=%p\n",
+          (void*)start, (void*)tok, (void*)locked_macros,
+          locked_macros ? (void*)locked_macros->stop_tok : NULL);
+  pop_macro_lock_until(start, tok);
+  return new_num_token(counter, start, tok);
 }
 
 static Token *interp_at_macro(Token *start)
 {
+  Token *tok = skip(start->next, "(");
   
+  if(tok->kind != TK_ISTR)
+    error_tok(start, "not an interpolated string");
+  
+  Token *itok = tok;
+  tok = skip(tok->next, ",");
+  
+  Token *idx_tok = read_macro_arg_one(&tok, tok, false);
+  
+  int64_t idx = eval_const_expr(idx_tok);
+  
+  Token *it = itok->interp_next;
+  if(it == NULL)
+    error_tok(start, "interpolate string does not contain any interpolations");
+  
+  int64_t count = idx;
+  while(count--)
+  {
+    it = it->interp_next;
+    if(it == NULL)
+      error_tok(start, "interpolate index %d out of bounds for %.*s", (int)idx, itok->len, itok->loc);
+  }
+  
+  tok = skip(tok, ")");
+  
+  fprintf(stderr, "pop_macro_lock_until: start=%p stop=%p locked_macros=%p locked_macros->stop_tok=%p\n",
+          (void*)start, (void*)tok, (void*)locked_macros,
+          locked_macros ? (void*)locked_macros->stop_tok : NULL);
+  pop_macro_lock_until(start, tok);
+  Token *ret = make_token(strndup(it->loc, it->len), it, tok);
+  return ret;
 }
 
-static Token *base_str_at_macro(Token *start)
+static Token *interp_literal_at_macro(Token *start)
 {
+  Token *tok = skip(start->next, "(");
   
+  if(tok->kind != TK_ISTR)
+    error_tok(start, "not an interpolated string");
+  
+  Token *itok = tok;
+  tok = skip(tok->next, ",");
+  
+  Token *idx_tok = read_macro_arg_one(&tok, tok, false);
+  int64_t idx = eval_const_expr(idx_tok);
+  
+  Token *it = itok->interp_str_next;
+  assert(it); // it being NULL makes no sense
+  
+  int64_t count = idx;
+  while(count--)
+  {
+    it = it->interp_str_next;
+    if(it == NULL)
+      error_tok(start, "literal index %d out of bounds for %.*s", (int)idx, itok->len, itok->loc);
+  }
+  
+  tok = skip(tok, ")");
+  
+  char *quoted = strndup(it->loc, it->len);
+  quoted[0] = '"';
+  quoted[it->len - 1] = '"';
+  
+  pop_macro_lock_until(start, tok);
+  Token *ret = make_token(quoted, it, tok);
+  ret->loc = quoted;
+
+  return ret;
 }
 
 
@@ -2066,7 +2102,7 @@ void init_macros(void) {
   
   add_builtin("__INTERP_COUNT__", interp_count_macro, true);
   add_builtin("__INTERP_AT__", interp_at_macro, true);
-  add_builtin("__BASE_STR_AT__", base_str_at_macro, true);
+  add_builtin("__INTERP_LITERAL_AT__", interp_literal_at_macro, true);
 }
 
 void dump_defines(FILE *out) {

--- a/preprocess.c
+++ b/preprocess.c
@@ -2059,6 +2059,79 @@ static Token *interp_literal_at_macro(Token *start)
   return ret;
 }
 
+static Token *interp_list_macro(Token *start)
+{
+  Token *tok = skip(start->next, "(");
+  
+  Token *itok = tok;
+  if(itok->kind != TK_ISTR)
+    error_tok(start, "not an interpolated string");
+  
+  Token *it = itok->interp_next;
+  
+  Token *arg2 = skip(itok->next, ",");
+  
+  Token *macro = split_paren(&tok, arg2);
+  
+  pop_macro_lock_until(start, tok);
+  
+  if(it == NULL || it->kind == TK_EOF)
+    return tok;
+  
+  Token head = {0};
+  Token *cur = &head;
+  while(it && it->kind != TK_EOF)
+  {
+    for(Token *t = macro; t->kind != TK_EOF; t = t->next)
+      cur = cur->next = copy_token(t);
+    cur = cur->next = make_token("(", tok, NULL);
+    for(Token *t = it; t->kind != TK_EOF; t = t->next)
+      cur = cur->next = copy_token(t);
+    cur = cur->next = make_token(")", tok, NULL);
+    it = it->interp_next;
+  }
+  cur->next = tok;
+  return head.next;
+}
+
+static Token *interp_literal_list_macro(Token *start)
+{
+  Token *tok = skip(start->next, "(");
+  
+  Token *itok = tok;
+  if(itok->kind != TK_ISTR)
+    error_tok(start, "not an interpolated string");
+  
+  Token *it = itok->interp_str_next;
+  
+  Token *arg2 = skip(itok->next, ",");
+  
+  Token *macro = split_paren(&tok, arg2);
+  
+  pop_macro_lock_until(start, tok);
+  
+  if(it == NULL || it->kind == TK_EOF)
+    return tok;
+  
+  Token head = {0};
+  Token *cur = &head;
+  while(it && it->kind != TK_EOF)
+  {
+    for(Token *t = macro; t->kind != TK_EOF; t = t->next)
+      cur = cur->next = copy_token(t);
+    
+    cur = cur->next = make_token("(", tok, NULL);
+    
+    char *quoted = strndup(it->loc, it->len);
+    quoted[0] = quoted[it->len - 1] = '"';
+    
+    cur = cur->next = make_token(quoted, it, NULL);
+    cur = cur->next = make_token(")", tok, NULL);
+    it = it->interp_str_next;
+  }
+  cur->next = tok;
+  return head.next;
+}
 
 void init_macros(void) {
   define_macro("__slimcc__", "1");
@@ -2116,6 +2189,8 @@ void init_macros(void) {
   add_builtin("__INTERP_LITERAL_COUNT__", interp_literal_count_macro, true);
   add_builtin("__INTERP_AT__", interp_at_macro, true);
   add_builtin("__INTERP_LITERAL_AT__", interp_literal_at_macro, true);
+  add_builtin("__INTERP_LIST__", interp_list_macro, true);
+  add_builtin("__INTERP_LITERAL_LIST__", interp_literal_list_macro, true);
 }
 
 void dump_defines(FILE *out) {

--- a/preprocess.c
+++ b/preprocess.c
@@ -802,6 +802,155 @@ static Token *subst(Token *tok, MacroContext *ctx) {
       continue;
     }
 
+    if (equal(tok, "__VA_SLICE_INTERNAL__") && consume(&tok, tok->next, "("))
+    {
+      MacroArg *start_arg = find_arg(&tok, tok, ctx);
+      Token *start_tok = read_const_expr(start_arg->tok);
+      int64_t start = eval_const_expr(start_tok);
+      
+      tok = skip(tok, ",");
+      
+      MacroArg *len_arg = find_arg(&tok, tok, ctx);
+      Token *len_tok = read_const_expr(len_arg->tok);
+      int64_t len = eval_const_expr(len_tok);
+      
+      if (start <= 0)
+      {
+        error_tok(start_tok, "__VA_SLICE__ Non-positive start");
+      }
+      if(len < 0)
+      {
+        error_tok(start_tok, "__VA_SLICE__ Negative length");
+      }
+      
+      MacroArg *vaarg;
+      if (!has_non_empty_va_arg(ctx, &vaarg))
+      {
+        continue;
+      }
+      
+      Token *arg_iter = vaarg->tok;
+      int level = 0;
+      for(int64_t i = 1 ; i < start && arg_iter->kind != TK_EOF ; i++)
+      {
+        while(!(level == 0 && equal(arg_iter, ",")) && arg_iter->kind != TK_EOF)
+        {
+          if(equal(arg_iter, "("))
+          {
+            level += 1;
+          }
+          if(equal(arg_iter, ")"))
+          {
+            level -= 1;
+          }
+          arg_iter = arg_iter->next;
+        }
+        
+        if(arg_iter->kind != TK_EOF)
+        {
+          arg_iter = arg_iter->next; // skip comma
+        }
+      }
+      
+      int64_t len_it = 0;
+      level = 0;
+      while(arg_iter->kind != TK_EOF && len_it < len)
+      {
+        while(!(level == 0 && equal(arg_iter, ",")) && arg_iter->kind != TK_EOF)
+        {
+          if(equal(arg_iter, "("))
+          {
+            level += 1;
+          }
+          if(equal(arg_iter, ")"))
+          {
+            level -= 1;
+          }
+          
+          cur = cur->next = copy_token(arg_iter);
+          arg_iter = arg_iter->next;
+        }
+        len_it += 1;
+        if(arg_iter->kind != TK_EOF && len_it < len)
+        {
+          cur = cur->next = copy_token(arg_iter);
+          arg_iter = arg_iter->next; // comma
+        }
+      }
+      
+      tok = tok->next; // skip final )
+      continue;
+    }
+    if(equal(tok, "__VA_COUNT_INTERNAL__") && consume(&tok, tok->next, "("))
+    {
+      tok = skip(tok, ")");
+      
+      MacroArg *vaarg;
+      if (!has_non_empty_va_arg(ctx, &vaarg))
+      {
+        cur = cur->next = new_num_token(0, tok, tok->next);
+        continue;
+      }
+      Token *arg_iter = vaarg->tok;
+      int64_t count = 0;
+      int level = 0;
+      while(arg_iter->kind != TK_EOF)
+      {
+        while(!(level == 0 && equal(arg_iter, ",")) && arg_iter->kind != TK_EOF)
+        {
+          if(equal(arg_iter, "("))
+          {
+            level += 1;
+          }
+          if(equal(arg_iter, ")"))
+          {
+            level -= 1;
+          }
+          arg_iter = arg_iter->next;
+        }
+        if(arg_iter->kind != TK_EOF)
+          arg_iter = arg_iter->next; // skip comma
+        
+        count += 1;
+      }
+      
+      cur = cur->next = new_num_token(count, tok, tok->next);
+      
+      continue;
+    }
+    if(equal(tok, "__REPEAT_INTERNAL__") && consume(&tok, tok->next, "("))
+    {
+      MacroArg *n_arg = find_arg(&tok, tok, ctx);
+      Token *n_tok = read_const_expr(n_arg->tok);
+      int64_t n = eval_const_expr(n_tok);
+      
+      tok = skip(tok, ")");
+      
+      MacroArg *vaarg = &ctx->args[ctx->m->arg_cnt - 1];
+      
+      int level = 0;
+      for(int64_t i = 0; i < n ; i++)
+      {
+        Token *arg_iter = vaarg->tok;
+        while(!(level == 0 && equal(arg_iter, ")")) && arg_iter->kind != TK_EOF)
+        {
+          if(equal(arg_iter, "("))
+          {
+            level += 1;
+          }
+          if(equal(arg_iter, ")"))
+          {
+            level -= 1;
+          }
+          
+          cur = cur->next = copy_token(arg_iter);
+          arg_iter = arg_iter->next;
+        }
+      }
+      
+      continue;
+    }
+    
     if (equal(tok, "__VA_TAIL__") && consume(&tok, tok->next, "(")) {
       Macro *tail_m = NULL;
       Token *rparen = NULL;
@@ -1788,6 +1937,79 @@ static Token *has_extension_macro(Token *start) {
   return new_bool_int_token(has_it, start, tok);
 }
 
+static void iter_interp_str(const char *str, int len, void(*on_found_interp)(const char *, int len, void *arg), void *arg)
+{
+  for(int i = 0 ; i < len - 1 ; i++)
+  {
+    if(str[i] == '{')
+    {
+      if(str[i + 1] == '{')
+      {
+        i++;
+      }
+      else
+      {
+        // probably should tokenize_until_unbalanced_closing_curly_brace
+        int interp_len = 0;
+        int single_quote = 0; // open brace adds 1
+        int double_quote = 0;
+        while(balance)
+        {
+          if(str[i] == '{')
+            balance += 1;
+          else if(str[i] == '}')
+            balance -= 1;
+        }
+        
+        on_found_interp(str, );
+      }
+    }
+  }
+}
+
+static Token *interp_count_macro(Token *start)
+{
+  Token *tok = skip(start, "(");
+  if(!equal(tok, "$"))
+  {
+    return new_num_token(0, start, tok);
+  }
+  tok = skip(tok, "$");
+  if(tok->kind != TK_STR)
+    return new_eof(start);
+  
+  const char *str = tok->loc + 1; // skip first quote
+  int len = tok->len - 2; // don't include first and last quotes
+  
+  int count = 0;
+  for(int i = 0 ; i < len - 1 ; i++)
+  {
+    if(str[i] == '{')
+    {
+      if(str[i + 1] == '{')
+      {
+        i++;
+      }
+      else
+      {
+        count += 1;
+        
+      }
+    }
+  }
+}
+
+static Token *interp_at_macro(Token *start)
+{
+  
+}
+
+static Token *base_str_at_macro(Token *start)
+{
+  
+}
+
+
 void init_macros(void) {
   define_macro("__slimcc__", "1");
   macro_head = macro_defs;
@@ -1818,6 +2040,10 @@ void init_macros(void) {
   define_macro("__x86_64", "1");
   define_macro("__x86_64__", "1");
 
+  read_macro_definition(&(Token*){}, tokenize(new_file("<built-in>", "__VA_SLICE__(s,l,...) __VA_SLICE_INTERNAL__(s,l)\n"), NULL, NULL));
+  read_macro_definition(&(Token*){}, tokenize(new_file("<built-in>", "__VA_COUNT__(...) __VA_COUNT_INTERNAL__()\n"), NULL, NULL));
+  read_macro_definition(&(Token*){}, tokenize(new_file("<built-in>", "__REPEAT__(n, ...) __REPEAT_INTERNAL__(n)\n"), NULL, NULL));
+
   add_builtin("__DATE__", date_macro, true);
   add_builtin("__TIME__", time_macro, true);
   add_builtin("__FILE__", file_macro, true);
@@ -1835,6 +2061,10 @@ void init_macros(void) {
   add_builtin("__has_include", has_include_macro, true);
   add_builtin("__has_include_next", has_include_next_macro, true);
   add_builtin("__has_embed", has_embed_macro, true);
+  
+  add_builtin("__INTERP_COUNT__", interp_count_macro, true);
+  add_builtin("__INTERP_AT__", interp_at_macro, true);
+  add_builtin("__BASE_STR_AT__", base_str_at_macro, true);
 }
 
 void dump_defines(FILE *out) {

--- a/slimcc.h
+++ b/slimcc.h
@@ -210,6 +210,7 @@ typedef enum {
   TK_KEYWORD, // Keywords
   TK_STR,     // String literals
   TK_ASM_STR,
+  TK_ISTR,    // Interpolated string
   TK_INT_NUM, // Integer Numeric literals
   TK_PP_NUM,  // Preprocessing numbers
   TK_FMARK,   // Filemarkers for -E
@@ -315,6 +316,10 @@ struct Token {
   int display_line_no;
   int display_file_no;
   Type *ty; // Used if TK_INT_NUM or TK_STR
+
+  Token *interp_next;
+  Token *interp_str_next;
+
   ANON_UNION_START
   Token *attr_next;
   Token *alloc_next;
@@ -342,6 +347,7 @@ File *new_file(const char *name, const char *contents);
 int add_display_file(const char *path);
 void tokenize_string_literal(Token *tok, Type *basety);
 Token *tokenize(File *file, SlashDelta *delta, Token **end);
+Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*, void*), void *arg);
 void convert_pp_number(Token *tok, Node *node);
 bool is_pp_token_int(Token *tok);
 TokenKind ident_keyword(Token *tok);

--- a/tokenize.c
+++ b/tokenize.c
@@ -582,10 +582,10 @@ static const char *interp_string_contains_interp(const char *p)
   for (; *p != '"'; p++) {
     if (*p == '\n' || *p == '\0')
       error_at(start, "unclosed string literal");
-    if (*p == '\\')
-      p++;
     if(*p == '\\' && p[1] == '$')
       p += 2;
+    if (*p == '\\')
+      p++;
     if(*p == '$' && p[1] == '{')
       return p;
   }

--- a/tokenize.c
+++ b/tokenize.c
@@ -502,20 +502,16 @@ static Token *asm_string_literal(const char *p, char end) {
   return tok;
 }
 
-static const char *string_literal_find_end(const char *p, char end_char) {
+// Find a closing double-quote.
+static const char *string_literal_end(const char *p) {
   const char *start = p;
-  for (; *p != end_char; p++) {
+  for (; *p != '\"'; p++) {
     if (*p == '\n' || *p == '\0')
       error_at(start, "unclosed string literal");
     if (*p == '\\')
       p++;
   }
   return p;
-}
-
-// Find a closing double-quote.
-static const char *string_literal_end(const char *p) {
-  return string_literal_find_end(p, '"');
 }
 
 static Token *read_string_literal_given_end(const char *start, const char *quote, const char *end, Type *ty)
@@ -556,7 +552,7 @@ static Token *read_string_literal(const char *start, const char *quote, Type *ty
 static bool stop_on_unbalanced_close_curly_brace(Token *tok, void *arg)
 {
   int *braces_open = arg;
-  
+
   if(equal(tok, "{"))
   {
     *braces_open += 1;
@@ -565,7 +561,7 @@ static bool stop_on_unbalanced_close_curly_brace(Token *tok, void *arg)
   {
     *braces_open -= 1;
   }
-  
+
   if(*braces_open == 0)
   {
     return false;
@@ -624,7 +620,7 @@ static Token *read_interp_string_literal(const char *start, const char *quote, T
 
       it = end->loc + end->len;
       Token *last = interps->interp_next;
-      
+
       if(last == end)
       {
         interps->interp_next = interps->interp_next->next;
@@ -635,7 +631,7 @@ static Token *read_interp_string_literal(const char *start, const char *quote, T
           last = last->next;
         last->next = end->next;
       }
-      
+
       interps = interps->interp_next;
       assert(it[-1] == '}');
     }
@@ -1123,7 +1119,7 @@ bool tokenize_cb_accept(Token *tok, void *arg)
 Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*, void*), void *arg) {
   if(cb == NULL)
     cb = tokenize_cb_accept;
-  
+
   current_file = file;
 
   const char *p = file->contents;

--- a/tokenize.c
+++ b/tokenize.c
@@ -584,7 +584,7 @@ static const char *interp_string_contains_interp(const char *p)
       error_at(start, "unclosed string literal");
     if (*p == '\\')
       p++;
-    if(*p == '$' && p[1] == '$')
+    if(*p == '\\' && p[1] == '$')
       p += 2;
     if(*p == '$' && p[1] == '{')
       return p;
@@ -599,26 +599,58 @@ static Token *read_interp_string_literal(const char *start, const char *quote, T
   Token interps_start = {};
   Token *strings = &strings_start;
   Token *interps = &interps_start;
-  
-  const char *it = quote + 1;
-  
+
+  const char *it = quote + 2;
+
   while(true)
   {
     const char *interp = interp_string_contains_interp(it);
-    
+
     if(interp)
     {
+      assert(*interp == '$');
+
+      strings = strings->interp_str_next = read_string_literal_given_end(it - 1, it - 1, interp, ty);
+      strings->next = new_token(TK_EOF, strings->loc + strings->len, strings->loc + strings->len);
+
+      it += strings->len - 2;
+
       int braces_open = 1;
-      Token *end;
-      
-      interps = interps->next = tokenize_cb(new_file("<built-in>", it + 2), NULL, &end, stop_on_unbalanced_close_curly_brace, &braces_open);
-      
-      strings = strings->next = read_string_literal_given_end(it - 1, it - 1, it, ty);
-      
+      Token *end = NULL;
+
+      interps->interp_next = tokenize_cb(new_file("<built-in>", it + 2), NULL, &end, stop_on_unbalanced_close_curly_brace, &braces_open);
+
+      assert(end);
+
       it = end->loc + end->len;
+      Token *last = interps->interp_next;
+      
+      if(last == end)
+      {
+        interps->interp_next = interps->interp_next->next;
+      }
+      else
+      {
+        while(last->next != end)
+          last = last->next;
+        last->next = end->next;
+      }
+      
+      interps = interps->interp_next;
       assert(it[-1] == '}');
     }
+    else
+    {
+      strings = strings->interp_str_next = read_string_literal(it - 1, it - 1, ty);
+      strings->next = new_token(TK_EOF, strings->loc + strings->len, strings->loc + strings->len);
+      break;
+    }
   }
+
+  Token *tok = new_token(TK_ISTR, start, strings->loc + strings->len);
+  tok->interp_str_next = strings_start.interp_str_next;
+  tok->interp_next = interps_start.interp_next;
+  return tok;
 }
 
 // Read a UTF-8-encoded string literal and transcode it in UTF-16.
@@ -1066,21 +1098,21 @@ void convert_ucn_ident(Token *tok) {
 }
 
 Token *tokenize(File *file, SlashDelta *delta, Token **end) {
-  return tokenize_cb(file, delta, end, NULL, NULL);
+  Token *tok = tokenize_cb(file, delta, end, NULL, NULL);
+  add_line_numbers(tok, file, delta);
+  return tok;
 }
 
 #define accept_or_break(t) \
 do { \
   Token *tok_to_check = t; \
-  if(!cb(tok_to_check, arg)) \
-  { \
-    tok_to_check->next = tok_freelist; \
-    tok_freelist = tok_to_check; \
-    goto out; \
-  } \
   cur = cur->next = tok_to_check; \
   p += cur->len; \
-  continue; \
+  if(!cb(tok_to_check, arg)) \
+  { \
+    goto break_loop; \
+  } \
+  goto continue_loop; \
 } while(0)
 
 bool tokenize_cb_accept(Token *tok, void *arg)
@@ -1101,6 +1133,7 @@ Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*,
   at_bol = true;
   has_space = false;
 
+  continue_loop:
   while (*p) {
     // Skip newline.
     if (*p == '\n') {
@@ -1146,12 +1179,6 @@ Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*,
       accept_or_break(new_pp_number(p, p2 + 1));
     }
 
-    // Punctuators
-    int punct_len = read_punct(p);
-    if (punct_len) {
-      accept_or_break(new_token(TK_PUNCT, p, p + punct_len));
-    }
-
     if (opt_cc1_asm_pp) {
       if (*p == '$') {
         accept_or_break(new_token(TK_PUNCT, p, p + 1));
@@ -1166,6 +1193,11 @@ Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*,
       // String literal
       if (*p == '"') {
         accept_or_break(read_string_literal(p, p, ty_pchar));
+      }
+
+      // Interpolated string
+      if(Startswith2(p, '$', '\"')) {
+        accept_or_break(read_interp_string_literal(p, p, ty_pchar));
       }
 
       // UTF-8 string literal
@@ -1217,6 +1249,12 @@ Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*,
       }
     }
 
+    // Punctuators
+    int punct_len = read_punct(p);
+    if (punct_len) {
+      accept_or_break(new_token(TK_PUNCT, p, p + punct_len));
+    }
+
     // Identifier or keyword
     Token *ident = read_ident(p);
     if (ident) {
@@ -1230,12 +1268,11 @@ Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*,
     error_at(p, "invalid token");
   }
 
-  out:
+  break_loop:
   if (end && cur != &head)
     *end = cur;
   cur->next = new_token(TK_EOF, p, p);
   cur->next->at_bol = true;
-  add_line_numbers(head.next, file, delta);
   return head.next;
 }
 

--- a/tokenize.c
+++ b/tokenize.c
@@ -505,7 +505,7 @@ static Token *asm_string_literal(const char *p, char end) {
 // Find a closing double-quote.
 static const char *string_literal_end(const char *p) {
   const char *start = p;
-  for (; *p != '\"'; p++) {
+  for (; *p != '"'; p++) {
     if (*p == '\n' || *p == '\0')
       error_at(start, "unclosed string literal");
     if (*p == '\\')

--- a/tokenize.c
+++ b/tokenize.c
@@ -578,12 +578,15 @@ static const char *interp_string_contains_interp(const char *p)
   for (; *p != '"'; p++) {
     if (*p == '\n' || *p == '\0')
       error_at(start, "unclosed string literal");
-    if(*p == '\\' && p[1] == '$')
+    if(*p == '\\' && p[1] == '{')
+    {
       p += 2;
+      continue;
+    }
+    if(*p == '{')
+      return p;
     if (*p == '\\')
       p++;
-    if(*p == '$' && p[1] == '{')
-      return p;
   }
   return NULL;
 }
@@ -604,17 +607,18 @@ static Token *read_interp_string_literal(const char *start, const char *quote, T
 
     if(interp)
     {
-      assert(*interp == '$');
+      assert(*interp == '{');
 
       strings = strings->interp_str_next = read_string_literal_given_end(it - 1, it - 1, interp, ty);
       strings->next = new_token(TK_EOF, strings->loc + strings->len, strings->loc + strings->len);
 
       it += strings->len - 2;
-
+      assert(*it == '{');
+      
       int braces_open = 1;
       Token *end = NULL;
 
-      interps->interp_next = tokenize_cb(new_file("<built-in>", it + 2), NULL, &end, stop_on_unbalanced_close_curly_brace, &braces_open);
+      interps->interp_next = tokenize_cb(new_file("<built-in>", it + 1), NULL, &end, stop_on_unbalanced_close_curly_brace, &braces_open);
 
       assert(end);
 
@@ -1192,7 +1196,7 @@ Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*,
       }
 
       // Interpolated string
-      if(Startswith2(p, '$', '\"')) {
+      if(Startswith2(p, 'f', '\"')) {
         accept_or_break(read_interp_string_literal(p, p, ty_pchar));
       }
 

--- a/tokenize.c
+++ b/tokenize.c
@@ -502,10 +502,9 @@ static Token *asm_string_literal(const char *p, char end) {
   return tok;
 }
 
-// Find a closing double-quote.
-static const char *string_literal_end(const char *p) {
+static const char *string_literal_find_end(const char *p, char end_char) {
   const char *start = p;
-  for (; *p != '"'; p++) {
+  for (; *p != end_char; p++) {
     if (*p == '\n' || *p == '\0')
       error_at(start, "unclosed string literal");
     if (*p == '\\')
@@ -514,8 +513,13 @@ static const char *string_literal_end(const char *p) {
   return p;
 }
 
-static Token *read_string_literal(const char *start, const char *quote, Type *ty) {
-  const char *end = string_literal_end(quote + 1);
+// Find a closing double-quote.
+static const char *string_literal_end(const char *p) {
+  return string_literal_find_end(p, '"');
+}
+
+static Token *read_string_literal_given_end(const char *start, const char *quote, const char *end, Type *ty)
+{
   char *buf = calloc(1, end - quote);
   int len = 0;
   bool invalid = false;
@@ -543,6 +547,78 @@ static Token *read_string_literal(const char *start, const char *quote, Type *ty
   tok->ty = array_of(ty, len + 1);
   tok->str = buf;
   return tok;
+}
+
+static Token *read_string_literal(const char *start, const char *quote, Type *ty) {
+  return read_string_literal_given_end(start, quote, string_literal_end(quote + 1), ty);
+}
+
+static bool stop_on_unbalanced_close_curly_brace(Token *tok, void *arg)
+{
+  int *braces_open = arg;
+  
+  if(equal(tok, "{"))
+  {
+    *braces_open += 1;
+  }
+  else if(equal(tok, "}"))
+  {
+    *braces_open -= 1;
+  }
+  
+  if(*braces_open == 0)
+  {
+    return false;
+  }
+  else
+  {
+    return true;
+  }
+}
+
+static const char *interp_string_contains_interp(const char *p)
+{
+  const char *start = p;
+  for (; *p != '"'; p++) {
+    if (*p == '\n' || *p == '\0')
+      error_at(start, "unclosed string literal");
+    if (*p == '\\')
+      p++;
+    if(*p == '$' && p[1] == '$')
+      p += 2;
+    if(*p == '$' && p[1] == '{')
+      return p;
+  }
+  return NULL;
+}
+
+static Token *read_interp_string_literal(const char *start, const char *quote, Type *ty)
+{
+  // find $, if ${}, then parse prev ptr with cur as a string literal, make sure to dup it and replace $$ with $
+  Token strings_start = {};
+  Token interps_start = {};
+  Token *strings = &strings_start;
+  Token *interps = &interps_start;
+  
+  const char *it = quote + 1;
+  
+  while(true)
+  {
+    const char *interp = interp_string_contains_interp(it);
+    
+    if(interp)
+    {
+      int braces_open = 1;
+      Token *end;
+      
+      interps = interps->next = tokenize_cb(new_file("<built-in>", it + 2), NULL, &end, stop_on_unbalanced_close_curly_brace, &braces_open);
+      
+      strings = strings->next = read_string_literal_given_end(it - 1, it - 1, it, ty);
+      
+      it = end->loc + end->len;
+      assert(it[-1] == '}');
+    }
+  }
 }
 
 // Read a UTF-8-encoded string literal and transcode it in UTF-16.
@@ -990,6 +1066,32 @@ void convert_ucn_ident(Token *tok) {
 }
 
 Token *tokenize(File *file, SlashDelta *delta, Token **end) {
+  return tokenize_cb(file, delta, end, NULL, NULL);
+}
+
+#define accept_or_break(t) \
+do { \
+  Token *tok_to_check = t; \
+  if(!cb(tok_to_check, arg)) \
+  { \
+    tok_to_check->next = tok_freelist; \
+    tok_freelist = tok_to_check; \
+    goto out; \
+  } \
+  cur = cur->next = tok_to_check; \
+  p += cur->len; \
+  continue; \
+} while(0)
+
+bool tokenize_cb_accept(Token *tok, void *arg)
+{
+  return true;
+}
+
+Token *tokenize_cb(File *file, SlashDelta *delta, Token **end, bool(*cb)(Token*, void*), void *arg) {
+  if(cb == NULL)
+    cb = tokenize_cb_accept;
+  
   current_file = file;
 
   const char *p = file->contents;
@@ -1041,127 +1143,94 @@ Token *tokenize(File *file, SlashDelta *delta, Token **end) {
     // Numeric literal
     const char *p2 = (*p == '.') ? p + 1 : p;
     if (Isdigit(*p2)) {
-      cur = cur->next = new_pp_number(p, p2 + 1);
-      p += cur->len;
-      continue;
+      accept_or_break(new_pp_number(p, p2 + 1));
     }
 
     // Punctuators
     int punct_len = read_punct(p);
     if (punct_len) {
-      cur = cur->next = new_token(TK_PUNCT, p, p + punct_len);
-      p += cur->len;
-      continue;
+      accept_or_break(new_token(TK_PUNCT, p, p + punct_len));
     }
 
     if (opt_cc1_asm_pp) {
       if (*p == '$') {
-        cur = cur->next = new_token(TK_PUNCT, p, p + 1);
-        p++;
-        continue;
+        accept_or_break(new_token(TK_PUNCT, p, p + 1));
       }
       if (*p == '"') {
-        cur = cur->next = asm_string_literal(p, '"');
-        p += cur->len;
-        continue;
+        accept_or_break(asm_string_literal(p, '"'));
       }
       if (*p == '\'') {
-        cur = cur->next = asm_string_literal(p, '\'');
-        p += cur->len;
-        continue;
+        accept_or_break(asm_string_literal(p, '\''));
       }
     } else {
       // String literal
       if (*p == '"') {
-        cur = cur->next = read_string_literal(p, p, ty_pchar);
-        p += cur->len;
-        continue;
+        accept_or_break(read_string_literal(p, p, ty_pchar));
       }
 
       // UTF-8 string literal
       if (Startswith3(p, 'u', '8', '\"')) {
         if (opt_std >= STD_C23)
-          cur = cur->next = read_string_literal(p, p + 2, ty_uchar);
+          accept_or_break(read_string_literal(p, p + 2, ty_uchar));
         else
-          cur = cur->next = read_string_literal(p, p + 2, ty_pchar);
-        p += cur->len;
-        continue;
+          accept_or_break(read_string_literal(p, p + 2, ty_pchar));
       }
 
       // UTF-16 string literal
       if (Startswith2(p, 'u', '\"')) {
-        cur = cur->next = read_utf16_string_literal(p, p + 1);
-        p += cur->len;
-        continue;
+        accept_or_break(read_utf16_string_literal(p, p + 1));
       }
 
       // Wide string literal
       if (Startswith2(p, 'L', '\"')) {
-        cur = cur->next = read_utf32_string_literal(p, p + 1, ty_wchar_t);
-        p += cur->len;
-        continue;
+        accept_or_break(read_utf32_string_literal(p, p + 1, ty_wchar_t));
       }
 
       // UTF-32 string literal
       if (Startswith2(p, 'U', '\"')) {
-        cur = cur->next = read_utf32_string_literal(p, p + 1, ty_char32_t);
-        p += cur->len;
-        continue;
+        accept_or_break(read_utf32_string_literal(p, p + 1, ty_char32_t));
       }
 
       // Character literal
       if (*p == '\'') {
-        cur = cur->next = read_char_literal(p);
-        p += cur->len;
-        continue;
+        accept_or_break(read_char_literal(p));
       }
 
       // UTF-8 character literal
       if (Startswith3(p, 'u', '8', '\'') && opt_std >= STD_C23) {
-        cur = cur->next = read_unicode_char_literal(p, p + 2, ty_uchar);
-        p += cur->len;
-        continue;
+        accept_or_break(read_unicode_char_literal(p, p + 2, ty_uchar));
       }
 
       // UTF-16 character literal
       if (Startswith2(p, 'u', '\'')) {
-        cur = cur->next = read_unicode_char_literal(p, p + 1, ty_char16_t);
-        p += cur->len;
-        continue;
+        accept_or_break(read_unicode_char_literal(p, p + 1, ty_char16_t));
       }
 
       // Wide character literal
       if (Startswith2(p, 'L', '\'')) {
-        cur = cur->next = read_unicode_char_literal(p, p + 1, ty_wchar_t);
-        p += cur->len;
-        continue;
+        accept_or_break(read_unicode_char_literal(p, p + 1, ty_wchar_t));
       }
 
       // UTF-32 character literal
       if (Startswith2(p, 'U', '\'')) {
-        cur = cur->next = read_unicode_char_literal(p, p + 1, ty_char32_t);
-        p += cur->len;
-        continue;
+        accept_or_break(read_unicode_char_literal(p, p + 1, ty_char32_t));
       }
     }
 
     // Identifier or keyword
     Token *ident = read_ident(p);
     if (ident) {
-      cur = cur->next = ident;
-      p += cur->len;
-      continue;
+      accept_or_break(ident);
     }
 
     if (*p == '\\') {
-      cur = cur->next = new_token(TK_PUNCT, p, p + 1);
-      p++;
-      continue;
+      accept_or_break(new_token(TK_PUNCT, p, p + 1));
     }
 
     error_at(p, "invalid token");
   }
 
+  out:
   if (end && cur != &head)
     *end = cur;
   cur->next = new_token(TK_EOF, p, p);


### PR DESCRIPTION
Hi.

I had an idea about how to add string interpolation into C. basically it goes like this:

`__INTERP_AT__(interpolated_string, 0)` expands into the token sequence at the 0th interpolation, for example:

```C
__INTERP_AT__(f" {abc} {x y z} ", 1) // expands into `x y z`
```
and also another mechanism, for verbatim literals:
```C
__INTERP_LITERAL_AT__(f"hello {abc} world", 1) // expands to " world"
```
I also added `__INTERP_COUNT__` and `__INTERP_LITERAL_COUNT__` for querying counts.

this doesn't actually achieve interpolation, it enables libraries to implement it using these primitives (and also my previously implemented `__REPEAT__`). I have my own string library [CGS](https://github.com/aalmkainzi/CGS/tree/slimcc-interp) and I added support in a branch for this interpolated strings:

```C
#include "cgs.c"

int main()
{
    char str[64];

    int x = 50;
    cgs_ifmt(str, f"{x * 20}");

    cgs_printi(f"{str}");
}
```
It works well, im happy with the results.

Not suggesting this should be merged or anything. Just wanted to share this in case interested.

// EDIT: changed the syntax to f-strings style
